### PR TITLE
Update to dispatch 0.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,5 +16,4 @@ libraryDependencies += "net.ruippeixotog" %% "scala-scraper" % "1.2.0"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 
 libraryDependencies += "com.amazonaws" % "aws-lambda-java-core" % "1.0.0"
-// Until https://github.com/dispatch/reboot/issues/134 is released
-libraryDependencies += "net.bzzt" %% "dispatch-core" % "0.12.0-SNAPSHOT"
+libraryDependencies += "net.databinder.dispatch" %% "dispatch-core" % "0.12.0"


### PR DESCRIPTION
Interestingly this appears to work on travis but not on my machine due to the scalafmt plugin - but I don't quite understand why. Seems related to the fact that scalafmt is not yet available for 2.12, which is tracked in https://github.com/olafurpg/scalafmt/issues/616, but not sure how that should interact with the rest of the build.